### PR TITLE
Explicitly declare dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+chatexchange
+tabulate

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,5 @@ setup (
     author = "Ashish Ahuja",
     author_email = "ashish.ahuja@sobotics.org",
     url = "https://github.com/SOBotics/Botpy",
+    install_requires=['chatexchange', 'tabulate']
 )


### PR DESCRIPTION
Depends on `chatexchange` and `tabulate`; make this explicit.