### PR TITLE
Bot.py: default _on_event_callback takes one argument

### DIFF
--- a/Source/Bot.py
+++ b/Source/Bot.py
@@ -45,7 +45,7 @@ class Bot(ce.client.Client):
         self._startup_message = self.name + " starting..."
         self._standby_message = "Switching to standby mode."
         self._failover_message = "Failover received."
-        self._on_event_callback = lambda: None
+        self._on_event_callback = lambda event: None
 
         background_tasks.append(BackgroundTask(self._command_manager.cleanup_finished_commands, interval=3))
         self._background_task_manager = BackgroundTaskManager(background_tasks)


### PR DESCRIPTION
I was getting warnings from PulseMonitor for the latest release when I wasn't using the callback myself. I hope adding an argument to the default lambda is a correct fix. (I suppose the code could also look for the callback to be `not None` at callback time and use a simpler default.)