### PR TITLE
Remove extraneous 'import pickle' statements

### DIFF
--- a/Source/Bot.py
+++ b/Source/Bot.py
@@ -399,9 +399,6 @@ class Bot(ce.client.Client):
             except IOError as ioerr:
                 logging.error("IOError occurred: ")
                 logging.error(str(ioerr))
-            except pickle.PickleError as perr:
-                logging.error("Pickling error occurred: ")
-                logging.error(str(perr))
 
     def _load_users(self):
         for room in self._rooms:
@@ -415,9 +412,6 @@ class Bot(ce.client.Client):
             except IOError as ioerr:
                 logging.error("IOError occurred: ")
                 logging.error(str(ioerr))
-            except pickle.PickleError as perr:
-                logging.error("Pickling error occurred: ")
-                logging.error(str(perr))
 
     def _convert_to_save_filename(self, id):
         return self._storage_prefix + self.name.replace(' ', '_') + '_room_' + str(id) + '_data'

--- a/Source/ChatRoom.py
+++ b/Source/ChatRoom.py
@@ -7,7 +7,6 @@
 #
 
 import os
-import pickle
 import weakref
 import logging
 

--- a/build/lib/BotpySE/Bot.py
+++ b/build/lib/BotpySE/Bot.py
@@ -14,7 +14,6 @@ from . import ChatUser
 from . import Utilities
 
 import os
-import pickle
 import json
 import jsonpickle as jp
 

--- a/build/lib/BotpySE/ChatRoom.py
+++ b/build/lib/BotpySE/ChatRoom.py
@@ -8,7 +8,6 @@
 
 import chatexchange as ce
 import os
-import pickle
 import weakref
 
 from . import ChatUser


### PR DESCRIPTION
As mentioned in #31

Also, a few except handlers in Bot.py specific to `pickle` -- I have **assumed** that there is nothing in `jsonpickle` which could cause these, and that they simply were left around from an earlier version of the code, but please review this particular assumption.

